### PR TITLE
Breves adaptações

### DIFF
--- a/forallx-yyc-preface.tex
+++ b/forallx-yyc-preface.tex
@@ -1,16 +1,16 @@
 \chapter{Prefácio}
 
 Como o título indica, este é um livro sobre lógica formal.
-A lógica formal é uma subdisciplina da filosofia que estuda relações de consequência, nas quais uma conclusão se segue de certas informações de partida, as premissas.
-Tais relações de consequência são estudadas por meio de \emph{linguagens formais}, isto é, linguagens precisamente definidas.
-Para essas linguagens formais é possível definir rigorosamente quando uma de suas sentenças se segue ou não de outras.
+A lógica formal estuda relações de consequência, nas quais uma conclusão se segue de certas informações de partida, as premissas.
+O aspecto formal advém do emprego de \emph{linguagens formais}, isto é, um simbolismo precisamente definido.
+Para estas linguagens formais é possível definir rigorosamente quando uma fórmula se segue ou não de outras.
 Uma definição de consequência juntamente com a linguagem formal respectiva compõem um \emph{sistema lógico}.
-Os sistemas lógicos, ou simplesmente \emph{lógicas} são produtos de uma atividade filosófica que ocupou-se em analisar e modelar práticas inferenciais envolvendo as noções de conjunção, disjunção, negação, condicional, necessidade, obrigatoriedade, provabilidade, crença, tempo, entre muitas outras.
+Os sistemas lógicos, ou simplesmente \emph{lógicas}, são produtos de uma investigação que ocupou-se em analisar e modelar práticas inferenciais envolvendo as noções de conjunção, disjunção, negação, condicional, necessidade, obrigatoriedade, provabilidade, crença, tempo, entre muitas outras.
 Este livro apresentará lógicas que exploram algumas destas noções.
 
 
 A parte~\ref{ch.intro} introduz o assunto e as noções da lógica de maneira informal, ainda sem utilizar uma linguagem formal.
-As partes \ref{ch.TFL}, \ref{ch.TruthTables} e \ref{ch.NDTFL} tratam da linguagem proposicional.  Nesta linguagem, as sentenças são formadas a partir de sentenças básicas através de certos termos (`ou', `e', `não', `se \dots então') que conectam sentenças mais simples de modo a formar outras sentenças mais complexas.
+As partes \ref{ch.TFL}, \ref{ch.TruthTables} e \ref{ch.NDTFL} tratam da linguagem proposicional.  Nesta linguagem, fórmulas complexas são obtidas de fórmulas simples ao serem combinadas usando certos conectivos, os quais corrempendem, no português, às expressões tais como `ou', `e', `não', `se \dots então'.
 A relação de consequência é discutida de duas maneiras:
 semanticamente, usando o método das tabelas de verdade (na Parte~\ref{ch.TruthTables}) e demonstrativamente, usando um sistema de derivações formais (na Parte~\ref{ch.NDTFL}).
 As partes \ref{ch.FOL}, \ref{ch.semantics} e \ref{ch.NDFOL} lidam com uma linguagem mais complexa, a da lógica de primeira ordem.
@@ -24,5 +24,4 @@ o tópico das formas normais (conjuntiva e disjuntiva) e da adequação expressi
 Nos apêndices, você encontrará uma discussão sobre notações alternativas para as linguagens tratadas neste texto, uma outra sobre sistemas de derivação alternativos, além  de um guia de referência rápida listando a maioria das regras e definições importantes.
 Os termos principais estão listados em um glossário no final.
 
-Este livro é mesmo Para Tod$x$s (para todas e para todos).
 Você é livre para copiar e redistribuir gratuitamente este material em qualquer meio ou formato, remixar, transformar e desenvolvê-lo para qualquer finalidade, mesmo comercialmente, desde que respeite as restrições da licença  \href{https://creativecommons.org/licenses/by/4.0/}{Creative Commons Attribution 4.0}.

--- a/forallx-yyc-preface.tex
+++ b/forallx-yyc-preface.tex
@@ -3,18 +3,18 @@
 Como o título indica, este é um livro sobre lógica formal.
 A lógica formal estuda relações de consequência, nas quais uma conclusão se segue de certas informações de partida, as premissas.
 O aspecto formal advém do emprego de \emph{linguagens formais}, isto é, um simbolismo precisamente definido.
-Para estas linguagens formais é possível definir rigorosamente quando uma fórmula se segue ou não de outras.
+Para estas linguagens formais é possível definir rigorosamente a relação de consequência.
 Uma definição de consequência juntamente com a linguagem formal respectiva compõem um \emph{sistema lógico}.
 Os sistemas lógicos, ou simplesmente \emph{lógicas}, são produtos de uma investigação que ocupou-se em analisar e modelar práticas inferenciais envolvendo as noções de conjunção, disjunção, negação, condicional, necessidade, obrigatoriedade, provabilidade, crença, tempo, entre muitas outras.
 Este livro apresentará lógicas que exploram algumas destas noções.
 
 
 A parte~\ref{ch.intro} introduz o assunto e as noções da lógica de maneira informal, ainda sem utilizar uma linguagem formal.
-As partes \ref{ch.TFL}, \ref{ch.TruthTables} e \ref{ch.NDTFL} tratam da linguagem proposicional.  Nesta linguagem, fórmulas complexas são obtidas de fórmulas simples ao serem combinadas usando certos conectivos, os quais corrempendem, no português, às expressões tais como `ou', `e', `não', `se \dots então'.
+As partes \ref{ch.TFL}, \ref{ch.TruthTables} e \ref{ch.NDTFL} tratam da lógica proposicional.  Nesta lógica,  se estuda certos conectivos, os quais corrempendem, no português, às expressões tais como `ou', `e', `não', `se \dots então'.
 A relação de consequência é discutida de duas maneiras:
 semanticamente, usando o método das tabelas de verdade (na Parte~\ref{ch.TruthTables}) e demonstrativamente, usando um sistema de derivações formais (na Parte~\ref{ch.NDTFL}).
-As partes \ref{ch.FOL}, \ref{ch.semantics} e \ref{ch.NDFOL} lidam com uma linguagem mais complexa, a da lógica de primeira ordem.
-Além dos conectivos da lógica proposicional, esta linguagem inclui também nomes, predicados, a relação de identidade e os quantificadores.
+As partes \ref{ch.FOL}, \ref{ch.semantics} e \ref{ch.NDFOL} lidam com uma lógica mais complexa, a lógica de primeira ordem.
+Além dos conectivos da lógica proposicional, a linguagem da lógica de primeira ordem inclui também nomes, predicados, a relação de identidade e os quantificadores.
 Esses elementos adicionais da linguagem a tornam muito mais expressiva do que a linguagem proposicional, e passaremos um bom tempo investigando o quanto se pode expressar nela.
 As noções da lógica de primeira ordem também são definidas tanto semanticamente, através de interpretações (na Parte \ref{ch.semantics}), quanto demonstrativamente (na Parte \ref{ch.NDFOL}), usando uma versão mais complexa do sistema de derivação formal introduzido na Parte~\ref{ch.NDTFL}.
 A Parte \ref{ch.ML} discute uma extensão da LPC (a lógica proposicional) obtida a partir de operadores não verofuncionais para a possibilidade e a necessidade, conhecida como lógica modal.


### PR DESCRIPTION
O impulso das adaptações foi, em primeiro lugar, remover demarcação territorial na filosofia, afinal lecionamos a matéria para outros cursos, e, em segundo lugar, buscar introduzir uma distinção entre fórmula e sentença, a começar aqui do prefácio.