### PR TITLE
Conserta formulação equivocada ou imprecisa

### DIFF
--- a/forallx-yyc-what.tex
+++ b/forallx-yyc-what.tex
@@ -375,7 +375,7 @@ De modo um pouco mais controverso, outros filósofos pensam que devemos permitir
 Antes de prosseguirmos, alguns esclarecimentos.
 Argumentos em nosso sentido, compostos por conclusões que (supostamente) se seguem de premissas, são usados o tempo todo no discurso cotidiano e científico.
 E em seu uso, os argumentos são apresentados para dar suporte ou mesmo provar as suas conclusões.
-Mas um argumento válido dá suporte para sua conclusão \emph{somente se} suas premissas forem todas verdadeiras.
+Mas um argumento válido prova, isto é, garante a verdade da sua conclusão \emph{somente se} suas premissas forem todas verdadeiras.
 Se o argumento é válido, sabemos que não é possível que sua conclusão seja falsa e suas premissas verdadeiras.
 Mas um argumento válido pode sim ter a conclusão falsa se alguma ou algumas de suas premissas também forem falsas.
 Ou seja, é sim perfeitamente possível que um argumento válido tenha conclusão que não é verdadeira.


### PR DESCRIPTION
Num argumento válido, as premissas sempre suportam a conclusão. Obviamente, o suporte é tão robusto quanto as bases que o suportam. O que a validade do argumento não garante é a verdade da conclusão (independente do que ocorre com as premissas). Isto é, a mera validade do argumento não *prova* a conclusão.