### PR TITLE
Coloca o exemplo diretamente em língua portuguesa

### DIFF
--- a/forallx-yyc-tfl.tex
+++ b/forallx-yyc-tfl.tex
@@ -1025,12 +1025,11 @@ Em português as sentenças podem ser \textit{ambíguas}, ou seja, podem ter mai
 %	\item[] Flying planes can be dangerous.
 %\end{earg}
 %There is one reading in which `flying' is used as an adjective which modifies `planes'. In this sense, what's claimed to be dangerous are airplanes which are in the process of flying.  In another reading, `flying' is a gerund: what's claimed to be dangerous is the act of flying a plane.  In the first case, you might use the sentence to warn someone who's about to launch a hot air baloon.  In the second case, you might use it to counsel someone against becoming a pilot.
-Um tipo diferente é a \emph{ambiguidade estrutural}. Isso ocorre quando uma sentença pode ser interpretada de maneiras diferentes e, dependendo da interpretação, um significado diferente é selecionado. Um exemplo famoso devido a Noam Chomsky é o seguinte:
+Um tipo diferente é a \emph{ambiguidade estrutural}. Isso ocorre quando uma sentença pode ser interpretada de maneiras diferentes e, dependendo da interpretação, um significado diferente é selecionado. Um exemplo é o seguinte:
 \begin{earg}
-\item[] \textit{Flying planes can be dangerous.}
+\item[] \textit{João viu um homem com binóculos.}
 \end {earg}
-Há uma leitura em que `flying' (voando) é usado como um adjetivo que modifica `planes' (aviões), resultando na afirmação de que aviões voando (\textit{flying planes}) podem ser perigosos (\textit{can be dangerous}). Em outra leitura, `flying' funciona como o verbo pilotar, resultando na afirmação de que pilotar aviões (\textit{flying planes}) pode ser perigoso (\textit{can be dangerous}). No primeiro caso, você pode usar a frase para alertar alguém que está prestes a lançar um balão de ar quente. No segundo, para aconselhar alguém a não se tornar um piloto. 
-
+A ambiguidade surge porque não está claro na estrutura da frase a quem ``com binóculos'' está se referindo: foi João que usou binóculos para ver o homem? ou o homem que João viu que estava com binóculos?
 %When the sentence is uttered, usually only one meaning is intended. Which of the possible meanings an utterance of a sentence intends is determined by context, or sometimes by how it is uttered (which parts of the sentence are stressed, for instance). Often one interpretation is much more likely to be intended, and in that case it will even be difficult to ``see'' the unintended reading.  This is often the reason why a joke works, as in this example from Groucho Marx:
 %\begin{earg}
 %	\item[] One morning I shot an elephant in my pajamas.


### PR DESCRIPTION
Esse fenômeno de ambiguidade estrutural é fácil de explicar em língua portuguesa, não tem porque colocar em inglês e ficar explicando a tradução.