### PR TITLE
Aprimora terminologia

### DIFF
--- a/forallx-yyc-truthtables.tex
+++ b/forallx-yyc-truthtables.tex
@@ -968,7 +968,7 @@ Se elas sustentam, então podemos confiar que o argumento é válido.\footnote{
 \section{Alcance e limites da LPC}\label{s:ParadoxesOfMaterialConditional}
 Atingimos, na seção anterior, um marco importante para os objetivos da lógica enquanto disciplina: um teste para a validade de argumentos!
 É fundamentalmente para fazer testes desse tipo que estudamos lógica.
-Estudamos lógica para saber distinguir os bons dos maus argumentos, e o teste de validade via tabelas de verdade, que aprendemos na seção anterior, corresponde a uma das respostas que a lógica pode nos dar.
+Estudamos lógica para saber distinguir os argumentos bons dos argumentos ruins, e o teste de validade via tabelas de verdade, que aprendemos na seção anterior, corresponde a uma das respostas que a lógica pode nos dar.
 %Há muitas outras que ainda não estudamos, claro.
 %\label{key}Este livro é apenas uma introdução ao estudo da lógica.
 É essencial, portanto, entendermos \emph{o alcance} e também \emph{os limites} desta nossa primeira conquista.

--- a/forallx-yyc-what.tex
+++ b/forallx-yyc-what.tex
@@ -7,7 +7,7 @@
 \chapter{Argumentos}
 \label{s:Arguments}
 
-%O assunto da lógica é a avaliação de argumentos; a identificação dos bons argumentos, separando-os dos maus.  
+%O assunto da lógica é a avaliação de argumentos; a identificação dos bons argumentos, separando-os dos ruins.  
 
 %Na linguagem do dia a dia, às vezes usamos a palavra `argumento' para falar de bate-bocas e desacordos verbais.
 %Se você e um amigo discutem nesse sentido, as coisas não estão indo bem entre vocês dois.
@@ -15,7 +15,7 @@
 
 %Um argumento, no sentido em que empregaremos aqui, é algo mais parecido com isto:
 
-O assunto da lógica é a avaliação de argumentos; a identificação dos bons argumentos, separando-os dos maus.
+O assunto da lógica é a avaliação de argumentos; a identificação dos bons argumentos, separando-os dos ruins.
 Na lógica formal, o foco está na noção de validade ou consequência lógica.
 A validade é uma qualidade de argumentos nos quais a conclusão é uma consequência lógica das premissas.
 Um \define{argument} é um grupo de sentenças que exprime um raciocínio.


### PR DESCRIPTION
Me parece que o contrário de um argumento bom é melhor caracterizado como um argumento ruim, não um argumento mau. O adjetivo "mau", com "u", carrega uma conotação moral acentuada que é alheia ao contexto lógico.

Agora, o uso destas expressões pode ter mudado desde quando as aprendi no século passado. Pode ser que "ruim" tenha se tornado sinônimo de "mau", e até mesmo de "mal"? Por exemplo, tenho escutado recentemente com certa frequência a frase "Isso vai dar ruim!" ou "Deu ruim!", em vez de "Isso vai dar mal!", o que soa muito estranho aos meus velhos e cansados ouvidos.

Enfim, sem querer ser pedante, acho que "ruim" é mais claro, tanto para jovens quanto velhos, mas estou ciente que posso estar simplesmente desatualizado com o uso corrente do português.